### PR TITLE
Update collapse-expand.js

### DIFF
--- a/src/main/java/org/concordion/ext/collapse/CollapseOutputDocumentParsingListener.java
+++ b/src/main/java/org/concordion/ext/collapse/CollapseOutputDocumentParsingListener.java
@@ -30,7 +30,7 @@ public class CollapseOutputDocumentParsingListener implements DocumentParsingLis
 	}
 
 	private String buildXpath() {
-		return "//*[@class='" + className + "']";
+		return String.format("//*[@class='%s']", className);
 	}
 
 	private void createToogleContainer(Element element) {
@@ -45,7 +45,7 @@ public class CollapseOutputDocumentParsingListener implements DocumentParsingLis
 		
 		
 		Element link = new Element("a");
-		link.addAttribute(new Attribute("href", "javascript:collapseExpand('" + id + "');"));
+		link.addAttribute(new Attribute("href", String.format("javascript:Collapsible.collapseExpand('%s');", id)));
 
 		link.appendChild(linkText);
 		
@@ -56,10 +56,10 @@ public class CollapseOutputDocumentParsingListener implements DocumentParsingLis
 	}
 
 	/**
-	 * Check if the id attribute on the element is present. 
+	 * Check if the id attribute on the element is present.
 	 * If yes  return it for usage in the javascript function
 	 * If not create and set an id attribute using the hashCode of the elements value.
-	 * 
+	 *
 	 * @param element
 	 * @return id of the element
 	 */

--- a/src/main/resources/org/concordion/ext/collapse/collapse-expand.js
+++ b/src/main/resources/org/concordion/ext/collapse/collapse-expand.js
@@ -1,10 +1,14 @@
-function collapseExpand(elementId) {
-	var ele = document.getElementById(elementId);
-	var collapsedHeight = parseInt(ele.getAttribute("collapsed-height"));
-	var collapsedHeightUnit = ele.getAttribute("collapsed-height-unit");
-	if (parseInt(ele.style.height, 10) !== collapsedHeight) {
-		ele.style.height = collapsedHeight + collapsedHeightUnit;
-	} else {
-		ele.style.height = ele.scrollHeight;
+var Collapsible = (function() {
+	var my = {};
+	my.collapseExpand = function(elementId) {
+		var ele = document.getElementById(elementId);
+		var collapsedHeight = parseInt(ele.getAttribute("collapsed-height"));
+		var collapsedHeightUnit = ele.getAttribute("collapsed-height-unit");
+		if (parseInt(ele.style.height, 10) !== collapsedHeight) {
+			ele.style.height = collapsedHeight + collapsedHeightUnit;
+		} else {
+			ele.style.height = ele.scrollHeight;
+		}
 	}
-}
+	return my;
+})();

--- a/src/test/resources/spec/concordion/ext/collapse/Collapse.html
+++ b/src/test/resources/spec/concordion/ext/collapse/Collapse.html
@@ -36,7 +36,7 @@ It does so by wrapping the element in a container and adding a link on top of th
   <p>When <span concordion:execute="#fragment=render(#snippet)">run</span> with a fixture that sets the name to "Frank", it becomes:</p>
 
         <pre class="html" concordion:assertEquals="#fragment">&lt;div class="toggleContainer"&gt;
-    &lt;a href="javascript:collapseExpand('id');"&gt;Expand / Collapse&lt;/a&gt;
+    &lt;a href="javascript:Collapsible.collapseExpand('id');"&gt;Expand / Collapse&lt;/a&gt;
     &lt;div id="id" class="collapsible" collapsed-height="1.5" collapsed-height-unit="em" style="height: 1.5em;"&gt;This should be collapsible.&lt;/div&gt;
 &lt;/div&gt;</pre>
 

--- a/src/test/resources/spec/concordion/ext/collapse/config/linktext/Linktext.html
+++ b/src/test/resources/spec/concordion/ext/collapse/config/linktext/Linktext.html
@@ -43,7 +43,7 @@ limitations under the License.
 		</p>
 
 		<pre class="html" concordion:assertEquals="#fragment">&lt;div class="toggleContainer"&gt;
-    &lt;a href="javascript:collapseExpand('id');"&gt;Custom Linktext&lt;/a&gt;
+    &lt;a href="javascript:Collapsible.collapseExpand('id');"&gt;Custom Linktext&lt;/a&gt;
     &lt;div id="id" class="collapsible" collapsed-height="1.5" collapsed-height-unit="em" style="height: 1.5em;"&gt;This should be collapsible.&lt;/div&gt;
 &lt;/div&gt;</pre>
 

--- a/src/test/resources/spec/concordion/ext/collapse/config/styleClass/StyleClass.html
+++ b/src/test/resources/spec/concordion/ext/collapse/config/styleClass/StyleClass.html
@@ -33,7 +33,7 @@ limitations under the License.
   <p>When <span concordion:execute="#fragment=render(#snippet)">run</span> the output is enhanced with the needed code for the collapse feature:</p>
   
         <pre class="html" concordion:assertEquals="#fragment">&lt;div class="toggleContainer"&gt;
-    &lt;a href="javascript:collapseExpand('id');"&gt;Expand / Collapse&lt;/a&gt;
+    &lt;a href="javascript:Collapsible.collapseExpand('id');"&gt;Expand / Collapse&lt;/a&gt;
     &lt;div id="id" class="myCustomClass" collapsed-height="1.5" collapsed-height-unit="em" style="height: 1.5em;"&gt;This should be collapsible.&lt;/div&gt;
 &lt;/div&gt;</pre>
 

--- a/src/test/resources/spec/concordion/ext/collapse/idHandling/IdHandling.html
+++ b/src/test/resources/spec/concordion/ext/collapse/idHandling/IdHandling.html
@@ -29,7 +29,7 @@ limitations under the License.
 
   <p>When <span concordion:execute="#fragment=renderAndRetriveJavascriptCall(#snippet)">run</span> the id is passed as parameter to the javascript function:</p>
 
-  <pre class="html" concordion:assertEquals="#fragment">javascript:collapseExpand('id');</pre>
+  <pre class="html" concordion:assertEquals="#fragment">javascript:Collapsible.collapseExpand('id');</pre>
 </div>
 
 <div class="example">
@@ -42,7 +42,7 @@ limitations under the License.
   <p>When <span concordion:execute="#fragment=render(#snippet)">run</span> an id is generated and used as parameter to the javascript function:</p>
 
   <pre class="html" concordion:assertEquals="#fragment">&lt;div class="toggleContainer"&gt;
-    &lt;a href="javascript:collapseExpand('1409716573');"&gt;Expand / Collapse&lt;/a&gt;
+    &lt;a href="javascript:Collapsible.collapseExpand('1409716573');"&gt;Expand / Collapse&lt;/a&gt;
     &lt;div class="collapsible" id="1409716573" collapsed-height="1.5" collapsed-height-unit="em" style="height: 1.5em;"&gt;This should be collapsible. With a generated id on the element.&lt;/div&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
Wrapped JS in a module to avoid clashes with other referenced JS. New way to call this function is Collapsible.collapseExpand()
